### PR TITLE
refactor: updated build gradle for tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,9 +65,29 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test:rules:1.2.0'
 
-    testCompile 'org.powermock:powermock:1.6.5'
-    testCompile 'org.powermock:powermock-module-junit4:1.6.5'
-    testCompile 'org.powermock:powermock-api-mockito:1.6.5'
+    testImplementation 'org.powermock:powermock:1.6.5'
+    testImplementation 'org.powermock:powermock-module-junit4:1.6.5'
+    testImplementation 'org.powermock:powermock-api-mockito:1.6.5'
+
+    androidTestImplementation "com.android.support.test.espresso:espresso-core:2.2.2"
+    androidTestImplementation 'com.android.support.test:runner:0.5'
+    androidTestImplementation "com.android.support.test.espresso:espresso-intents:2.2.2"
+/**
+ * AccessibilityChecks
+ * CountingIdlingResource
+ * DrawerActions
+ * DrawerMatchers
+ * PickerActions (Time and Date picker)
+ * RecyclerViewActions
+ */
+    androidTestImplementation("com.android.support.test.espresso:espresso-contrib:2.2.2") {
+        exclude group: 'com.android.support', module: 'appcompat'
+        exclude group: 'com.android.support', module: 'support-v4'
+        exclude group: 'com.android.support', module: 'support-v7'
+        exclude group: 'com.android.support', module: 'design'
+        exclude module: 'support-annotations'
+        exclude module: 'recyclerview-v7'
+    }
 
 }
 


### PR DESCRIPTION
The tests with espresso contrib should no longer have a red underline in their import statements.